### PR TITLE
Adding functionality for derived note types

### DIFF
--- a/src/rust/src/wallet.rs
+++ b/src/rust/src/wallet.rs
@@ -1426,10 +1426,10 @@ pub extern "C" fn zsa_get_derived_note_type(
     let mut asset_desc_vec = vec![];
     unsafe {
         assert!(!asset_desc_ptr.is_null());
+        assert!(!note_type_ret.is_null());
         for i in 0..asset_desc_len {
             asset_desc_vec.push(*asset_desc_ptr.add(i));
         }
-        assert!(!note_type_ret.is_null());
         *note_type_ret = NoteType::derive(&*ik_ptr, asset_desc_vec).to_bytes();
     }
     true


### PR DESCRIPTION
This adds functionality for getting ZSA derived note types into the client across the FFI bridge. 

For a basic sanity test, please switch to `va_debug_branch` and run `./src/test/test_bitcoin`