### PR TITLE
Adding note types for orchard_bundle_add_recipient (Review fourth)

### DIFF
--- a/.cargo/config.offline
+++ b/.cargo/config.offline
@@ -6,7 +6,7 @@ replace-with = "vendored-sources"
 
 [source."https://github.com/QED-it/orchard.git"]
 git = "https://github.com/QED-it/orchard.git"
-rev = "ac71bc752847f36b23d25ad054f69b647cbed167"
+rev = "60a17a2179d0a4b539b23cd5410045b5d3107ef1"
 replace-with = "vendored-sources"
 
 [source.vendored-sources]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.2.0"
-source = "git+https://github.com/QED-it/orchard.git?rev=ac71bc752847f36b23d25ad054f69b647cbed167#ac71bc752847f36b23d25ad054f69b647cbed167"
+source = "git+https://github.com/QED-it/orchard.git?rev=60a17a2179d0a4b539b23cd5410045b5d3107ef1#60a17a2179d0a4b539b23cd5410045b5d3107ef1"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,5 @@ panic = 'abort'
 codegen-units = 1
 
 [patch.crates-io]
-orchard = {git = "https://github.com/QED-it/orchard.git", rev = "ac71bc752847f36b23d25ad054f69b647cbed167"}
+orchard = {git = "https://github.com/QED-it/orchard.git", rev = "60a17a2179d0a4b539b23cd5410045b5d3107ef1"}
+

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -1452,14 +1452,15 @@ TEST(ChecktransactionTests, NU5AcceptsOrchardShieldedCoinbase) {
         .ToIncomingViewingKey()
         .Address(0);
     uint256 ovk;
-    builder.AddOutput(ovk, to, CAmount(123456), std::nullopt);
+    NoteType noteTypeZEC;
+    builder.AddOutput(ovk, to, CAmount(123456), noteTypeZEC, std::nullopt);
 
     // orchard::Builder pads to two Actions, but does so using a "no OVK" policy for
     // dummy outputs, which violates coinbase rules requiring all shielded outputs to
     // be recoverable. We manually add a dummy output to sidestep this issue.
     // TODO: If/when we have funding streams going to Orchard recipients, this dummy
     // output can be removed.
-    builder.AddOutput(ovk, to, 0, std::nullopt);
+    builder.AddOutput(ovk, to, 0, noteTypeZEC, std::nullopt);
 
     auto bundle = builder
         .Build().value()
@@ -1572,14 +1573,15 @@ TEST(ChecktransactionTests, NU5EnforcesOrchardRulesOnShieldedCoinbase) {
         .ToIncomingViewingKey()
         .Address(0);
     uint256 ovk;
-    builder.AddOutput(ovk, to, CAmount(1000), std::nullopt);
+    NoteType noteTypeZEC;
+    builder.AddOutput(ovk, to, CAmount(1000), noteTypeZEC, std::nullopt);
 
     // orchard::Builder pads to two Actions, but does so using a "no OVK" policy for
     // dummy outputs, which violates coinbase rules requiring all shielded outputs to
     // be recoverable. We manually add a dummy output to sidestep this issue.
     // TODO: If/when we have funding streams going to Orchard recipients, this dummy
     // output can be removed.
-    builder.AddOutput(ovk, to, 0, std::nullopt);
+    builder.AddOutput(ovk, to, 0, noteTypeZEC, std::nullopt);
 
     auto bundle = builder
         .Build().value()

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -271,8 +271,9 @@ public:
 
         // Shielded coinbase outputs must be recoverable with an all-zeroes ovk.
         uint256 ovk;
+        NoteType noteTypeZEC;
         auto miner_reward = SetFoundersRewardAndGetMinerValue(ctx);
-        builder.AddOutput(ovk, to, miner_reward, std::nullopt);
+        builder.AddOutput(ovk, to, miner_reward, noteTypeZEC, std::nullopt);
 
         // orchard::Builder pads to two Actions, but does so using a "no OVK" policy for
         // dummy outputs, which violates coinbase rules requiring all shielded outputs to
@@ -285,7 +286,7 @@ public:
             .ToFullViewingKey()
             .ToIncomingViewingKey()
             .Address(0);
-        builder.AddOutput(ovk, dummyTo, 0, std::nullopt);
+        builder.AddOutput(ovk, dummyTo, 0, noteTypeZEC, std::nullopt);
 
         auto bundle = builder.Build();
         if (!bundle.has_value()) {

--- a/src/note_type.cpp
+++ b/src/note_type.cpp
@@ -18,3 +18,7 @@ NoteType::NoteType(unsigned char tid[]) {
         type_id[i] = tid[i];
     }
 }
+
+const unsigned char *NoteType::get_type() {
+    return type_ptr;
+}

--- a/src/note_type.cpp
+++ b/src/note_type.cpp
@@ -26,5 +26,5 @@ void NoteType::getNoteType(unsigned char noteType[ZC_ORCHARD_NOTE_TYPE_SIZE]) {
 }
 
 const unsigned char *NoteType::get_type() {
-    return type_ptr;
+    return &type_id[0];
 }

--- a/src/note_type.cpp
+++ b/src/note_type.cpp
@@ -19,6 +19,9 @@ NoteType::NoteType(unsigned char tid[]) {
     }
 }
 
-const unsigned char *NoteType::get_type() {
-    return type_ptr;
+void NoteType::getNoteType(unsigned char noteType[ZC_ORCHARD_NOTE_TYPE_SIZE]) {
+    for (int i = 0; i < ZC_ORCHARD_NOTE_TYPE_SIZE; i++) {
+        noteType[i] = type_id[i];
+    }
 }
+

--- a/src/note_type.cpp
+++ b/src/note_type.cpp
@@ -25,3 +25,6 @@ void NoteType::getNoteType(unsigned char noteType[ZC_ORCHARD_NOTE_TYPE_SIZE]) {
     }
 }
 
+const unsigned char *NoteType::get_type() {
+    return type_ptr;
+}

--- a/src/note_type.h
+++ b/src/note_type.h
@@ -17,7 +17,6 @@ class NoteType
 private:
 //    std::array<uint8_t, ZC_ORCHARD_NOTE_TYPE_SIZE> type_id;
     unsigned char type_id[ZC_ORCHARD_NOTE_TYPE_SIZE];
-    const unsigned char* type_ptr = &type_id[0];
 
 public:
     NoteType();

--- a/src/note_type.h
+++ b/src/note_type.h
@@ -17,13 +17,12 @@ class NoteType
 private:
 //    std::array<uint8_t, ZC_ORCHARD_NOTE_TYPE_SIZE> type_id;
     unsigned char type_id[ZC_ORCHARD_NOTE_TYPE_SIZE];
-    const unsigned char* type_ptr = &type_id[0];
 
 public:
     NoteType();
     NoteType(unsigned char tid[ZC_ORCHARD_NOTE_TYPE_SIZE]);
 
-    const unsigned char* get_type();
+    void getNoteType(unsigned char noteType[ZC_ORCHARD_NOTE_TYPE_SIZE]);
 };
 
 #endif //ZCASH_NOTE_TYPE_H

--- a/src/note_type.h
+++ b/src/note_type.h
@@ -17,11 +17,13 @@ class NoteType
 private:
 //    std::array<uint8_t, ZC_ORCHARD_NOTE_TYPE_SIZE> type_id;
     unsigned char type_id[ZC_ORCHARD_NOTE_TYPE_SIZE];
+    const unsigned char* type_ptr = &type_id[0];
 
 public:
     NoteType();
     NoteType(unsigned char tid[ZC_ORCHARD_NOTE_TYPE_SIZE]);
 
+    const unsigned char* get_type();
     void getNoteType(unsigned char noteType[ZC_ORCHARD_NOTE_TYPE_SIZE]);
 };
 

--- a/src/note_type.h
+++ b/src/note_type.h
@@ -17,10 +17,13 @@ class NoteType
 private:
 //    std::array<uint8_t, ZC_ORCHARD_NOTE_TYPE_SIZE> type_id;
     unsigned char type_id[ZC_ORCHARD_NOTE_TYPE_SIZE];
+    const unsigned char* type_ptr = &type_id[0];
 
 public:
     NoteType();
     NoteType(unsigned char tid[ZC_ORCHARD_NOTE_TYPE_SIZE]);
+
+    const unsigned char* get_type();
 };
 
 #endif //ZCASH_NOTE_TYPE_H

--- a/src/rust/include/rust/builder.h
+++ b/src/rust/include/rust/builder.h
@@ -63,7 +63,7 @@ bool orchard_builder_add_recipient(
     const unsigned char* ovk,
     const OrchardRawAddressPtr* recipient,
     uint64_t value,
-    const unsigned char* noteType,
+    unsigned char noteType[32],
     const unsigned char* memo);
 
 /// Builds a bundle containing the given spent notes and recipients.

--- a/src/rust/include/rust/builder.h
+++ b/src/rust/include/rust/builder.h
@@ -63,7 +63,7 @@ bool orchard_builder_add_recipient(
     const unsigned char* ovk,
     const OrchardRawAddressPtr* recipient,
     uint64_t value,
-    unsigned char noteType[32],
+    const unsigned char* noteType,
     const unsigned char* memo);
 
 /// Builds a bundle containing the given spent notes and recipients.

--- a/src/rust/include/rust/builder.h
+++ b/src/rust/include/rust/builder.h
@@ -63,6 +63,7 @@ bool orchard_builder_add_recipient(
     const unsigned char* ovk,
     const OrchardRawAddressPtr* recipient,
     uint64_t value,
+    const unsigned char* noteType,
     const unsigned char* memo);
 
 /// Builds a bundle containing the given spent notes and recipients.

--- a/src/rust/src/builder_ffi.rs
+++ b/src/rust/src/builder_ffi.rs
@@ -94,7 +94,7 @@ pub extern "C" fn orchard_builder_add_recipient(
     ovk: *const [u8; 32],
     recipient: *const orchard::Address,
     value: u64,
-    note_type: [u8; 32],
+    note_type: *const [u8; 32],
     memo: *const [u8; 512],
 ) -> bool {
     let builder = unsafe { builder.as_mut() }.expect("Builder may not be null.");
@@ -103,7 +103,9 @@ pub extern "C" fn orchard_builder_add_recipient(
         .map(OutgoingViewingKey::from);
     let recipient = unsafe { recipient.as_ref() }.expect("Recipient may not be null.");
     let value = NoteValue::from_raw(value);
-    let note_type = NoteType::from_bytes(&note_type).unwrap();
+    let note_type =
+        NoteType::from_bytes(unsafe { note_type.as_ref() }.expect("Note type may not be null."))
+            .unwrap();
     let memo = unsafe { memo.as_ref() }.copied();
 
     match builder.add_recipient(ovk, *recipient, value, note_type, memo) {

--- a/src/rust/src/builder_ffi.rs
+++ b/src/rust/src/builder_ffi.rs
@@ -94,7 +94,7 @@ pub extern "C" fn orchard_builder_add_recipient(
     ovk: *const [u8; 32],
     recipient: *const orchard::Address,
     value: u64,
-    // note_type: *const [u8; 32],
+    note_type: *const [u8; 32],
     memo: *const [u8; 512],
 ) -> bool {
     let builder = unsafe { builder.as_mut() }.expect("Builder may not be null.");
@@ -103,7 +103,7 @@ pub extern "C" fn orchard_builder_add_recipient(
         .map(OutgoingViewingKey::from);
     let recipient = unsafe { recipient.as_ref() }.expect("Recipient may not be null.");
     let value = NoteValue::from_raw(value);
-    let note_type = NoteType::native();
+    let note_type = unsafe { NoteType::from_bytes(&*note_type).unwrap() };
     let memo = unsafe { memo.as_ref() }.copied();
 
     match builder.add_recipient(ovk, *recipient, value, note_type, memo) {

--- a/src/rust/src/builder_ffi.rs
+++ b/src/rust/src/builder_ffi.rs
@@ -94,7 +94,7 @@ pub extern "C" fn orchard_builder_add_recipient(
     ovk: *const [u8; 32],
     recipient: *const orchard::Address,
     value: u64,
-    note_type: *const [u8; 32],
+    // note_type: *const [u8; 32],
     memo: *const [u8; 512],
 ) -> bool {
     let builder = unsafe { builder.as_mut() }.expect("Builder may not be null.");
@@ -103,10 +103,10 @@ pub extern "C" fn orchard_builder_add_recipient(
         .map(OutgoingViewingKey::from);
     let recipient = unsafe { recipient.as_ref() }.expect("Recipient may not be null.");
     let value = NoteValue::from_raw(value);
-    let note_type = NoteType::native().to_bytes();
+    let note_type = NoteType::native();
     let memo = unsafe { memo.as_ref() }.copied();
 
-    match builder.add_recipient(ovk, *recipient, value, memo) {
+    match builder.add_recipient(ovk, *recipient, value, note_type, memo) {
         Ok(()) => true,
         Err(e) => {
             error!("Failed to add Orchard recipient: {}", e);

--- a/src/rust/src/builder_ffi.rs
+++ b/src/rust/src/builder_ffi.rs
@@ -94,7 +94,7 @@ pub extern "C" fn orchard_builder_add_recipient(
     ovk: *const [u8; 32],
     recipient: *const orchard::Address,
     value: u64,
-    note_type: *const [u8; 32],
+    note_type: [u8; 32],
     memo: *const [u8; 512],
 ) -> bool {
     let builder = unsafe { builder.as_mut() }.expect("Builder may not be null.");
@@ -103,7 +103,7 @@ pub extern "C" fn orchard_builder_add_recipient(
         .map(OutgoingViewingKey::from);
     let recipient = unsafe { recipient.as_ref() }.expect("Recipient may not be null.");
     let value = NoteValue::from_raw(value);
-    let note_type = unsafe { NoteType::from_bytes(&*note_type).unwrap() };
+    let note_type = NoteType::from_bytes(&note_type).unwrap();
     let memo = unsafe { memo.as_ref() }.copied();
 
     match builder.add_recipient(ovk, *recipient, value, note_type, memo) {

--- a/src/rust/src/builder_ffi.rs
+++ b/src/rust/src/builder_ffi.rs
@@ -5,6 +5,7 @@ use std::slice;
 use incrementalmerkletree::Hashable;
 use libc::size_t;
 use orchard::keys::SpendingKey;
+use orchard::note::NoteType;
 use orchard::{
     builder::{Builder, InProgress, Unauthorized, Unproven},
     bundle::{Authorized, Flags},
@@ -93,6 +94,7 @@ pub extern "C" fn orchard_builder_add_recipient(
     ovk: *const [u8; 32],
     recipient: *const orchard::Address,
     value: u64,
+    note_type: *const [u8; 32],
     memo: *const [u8; 512],
 ) -> bool {
     let builder = unsafe { builder.as_mut() }.expect("Builder may not be null.");
@@ -101,6 +103,7 @@ pub extern "C" fn orchard_builder_add_recipient(
         .map(OutgoingViewingKey::from);
     let recipient = unsafe { recipient.as_ref() }.expect("Recipient may not be null.");
     let value = NoteValue::from_raw(value);
+    let note_type = NoteType::native().to_bytes();
     let memo = unsafe { memo.as_ref() }.copied();
 
     match builder.add_recipient(ovk, *recipient, value, memo) {

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -70,12 +70,14 @@ void Builder::AddOutput(
         throw std::logic_error("orchard::Builder has already been used");
     }
 
+    unsigned char noteTypeVal[ZC_ORCHARD_NOTE_TYPE_SIZE];
+    noteType.getNoteType(noteTypeVal);
     orchard_builder_add_recipient(
         inner.get(),
         ovk.has_value() ? ovk->begin() : nullptr,
         to.inner.get(),
         value,
-        noteType.get_type(),
+        noteTypeVal,
         memo.has_value() ? memo->data() : nullptr);
 
     hasActions = true;

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -70,14 +70,12 @@ void Builder::AddOutput(
         throw std::logic_error("orchard::Builder has already been used");
     }
 
-    unsigned char noteTypeVal[ZC_ORCHARD_NOTE_TYPE_SIZE];
-    noteType.getNoteType(noteTypeVal);
     orchard_builder_add_recipient(
         inner.get(),
         ovk.has_value() ? ovk->begin() : nullptr,
         to.inner.get(),
         value,
-        noteTypeVal,
+        noteType.get_type(),
         memo.has_value() ? memo->data() : nullptr);
 
     hasActions = true;

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -347,7 +347,8 @@ void TransactionBuilder::AddOrchardOutput(
         }
     }
 
-    orchardBuilder.value().AddOutput(ovk, to, value, memo);
+    NoteType noteTypeZEC;
+    orchardBuilder.value().AddOutput(ovk, to, value, noteTypeZEC, memo);
     valueBalanceOrchard -= value;
 }
 

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -63,6 +63,7 @@ void Builder::AddOutput(
     const std::optional<uint256>& ovk,
     const libzcash::OrchardRawAddress& to,
     CAmount value,
+    NoteType noteType,
     const std::optional<std::array<unsigned char, ZC_MEMO_SIZE>>& memo)
 {
     if (!inner) {
@@ -74,6 +75,7 @@ void Builder::AddOutput(
         ovk.has_value() ? ovk->begin() : nullptr,
         to.inner.get(),
         value,
+        noteType.get_type(),
         memo.has_value() ? memo->data() : nullptr);
 
     hasActions = true;

--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -19,6 +19,8 @@
 #include "zcash/Note.hpp"
 #include "zcash/NoteEncryption.hpp"
 
+#include "note_type.h"
+
 #include <optional>
 
 #include <rust/builder.h>
@@ -112,6 +114,7 @@ public:
         const std::optional<uint256>& ovk,
         const libzcash::OrchardRawAddress& to,
         CAmount value,
+        NoteType noteType,
         const std::optional<std::array<unsigned char, ZC_MEMO_SIZE>>& memo);
 
     /// Returns `true` if any spends or outputs have been added to this builder. This can


### PR DESCRIPTION
This PR adds the note type functionality for the orchard bundles, specifically the orchard_bundle_add_recipient function. 
Subsequent uses of this modified function are tweaked so that they set the note type to be the native ZEC.