### PR TITLE
Adding note types to action spend data structures (Review second)

### DIFF
--- a/src/rust/include/rust/orchard/wallet.h
+++ b/src/rust/include/rust/orchard/wallet.h
@@ -282,7 +282,8 @@ struct RawOrchardActionSpend {
     uint32_t outpointActionIdx;
     OrchardRawAddressPtr* receivedAt;
     CAmount noteValue;
-};  //TODO: add noteType?
+    unsigned char noteTypeRaw[32];
+};
 
 /**
  * A C struct used to transfer Orchard action output information across the FFI boundary.

--- a/src/rust/src/wallet.rs
+++ b/src/rust/src/wallet.rs
@@ -1079,7 +1079,8 @@ pub struct FFIActionSpend {
     outpoint_action_idx: u32,
     received_at: *mut Address,
     value: i64,
-} //TODO: add note_type?
+    note_type: [u8; 32],
+}
 
 /// A type used to pass decrypted output information across the FFI boundary.
 /// This must have the same representation as `struct RawOrchardOutputData`
@@ -1151,6 +1152,7 @@ pub extern "C" fn orchard_wallet_get_txdata(
                         outpoint_action_idx: outpoint.action_idx as u32,
                         received_at: Box::into_raw(Box::new(dnote.note.recipient())),
                         value: dnote.note.value().inner() as i64,
+                        note_type: dnote.note.note_type().to_bytes(),
                     })
             }) {
                 unsafe { (spend_push_cb.unwrap())(callback_receiver, spend) };

--- a/src/wallet/orchard.h
+++ b/src/wallet/orchard.h
@@ -123,9 +123,10 @@ private:
     OrchardOutPoint outPoint;
     libzcash::OrchardRawAddress receivedAt;
     CAmount noteValue;
+    NoteType noteType;
 public:
-    OrchardActionSpend(OrchardOutPoint outPoint, libzcash::OrchardRawAddress receivedAt, CAmount noteValue):
-        outPoint(outPoint), receivedAt(receivedAt), noteValue(noteValue) { }
+    OrchardActionSpend(OrchardOutPoint outPoint, libzcash::OrchardRawAddress receivedAt, CAmount noteValue, NoteType noteType):
+        outPoint(outPoint), receivedAt(receivedAt), noteValue(noteValue), noteType(noteType) { }
 
     OrchardOutPoint GetOutPoint() const {
         return outPoint;
@@ -137,6 +138,10 @@ public:
 
     CAmount GetNoteValue() const {
         return noteValue;
+    }
+
+    NoteType GetNoteType() const {
+        return noteType;
     }
 };
 
@@ -467,7 +472,7 @@ public:
         auto spend = OrchardActionSpend(
                 OrchardOutPoint(txid, rawSpend.outpointActionIdx),
                 libzcash::OrchardRawAddress(rawSpend.receivedAt),
-                rawSpend.noteValue);
+                rawSpend.noteValue, NoteType(rawSpend.noteTypeRaw));
         reinterpret_cast<OrchardActions*>(receiver)->AddSpend(rawSpend.spendActionIdx, spend);
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2347,7 +2347,6 @@ UniValue getwalletinfo(const UniValue& params, bool fHelp)
     obj.pushKV("txcount",       (int)pwalletMain->mapWallet.size());
     obj.pushKV("keypoololdest", pwalletMain->GetOldestKeyPoolTime());
     obj.pushKV("keypoolsize",   (int)pwalletMain->GetKeyPoolSize());
-//    obj.pushKV("zec_type", zsa_get_native_note_type());
     if (pwalletMain->IsCrypted())
         obj.pushKV("unlocked_until", nWalletUnlockTime);
     obj.pushKV("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK()));


### PR DESCRIPTION
This PR adds note type support for `FFIActionSpend`, `RawOrchardActionSpend`, and `OrchardActionSpend`.
