### PR TITLE
Adding note types to action output data structures (Review third)

### DIFF
--- a/src/rust/include/rust/orchard/wallet.h
+++ b/src/rust/include/rust/orchard/wallet.h
@@ -294,6 +294,7 @@ struct RawOrchardActionOutput {
     uint32_t outputActionIdx;
     OrchardRawAddressPtr* recipient;
     CAmount noteValue;
+    unsigned char noteTypeRaw[32];
     unsigned char memo[512];
     bool isOutgoing;
 };  //TODO: add noteType?

--- a/src/rust/src/wallet.rs
+++ b/src/rust/src/wallet.rs
@@ -1090,6 +1090,7 @@ pub struct FFIActionOutput {
     action_idx: u32,
     recipient: *mut Address,
     value: i64,
+    note_type: [u8; 32],
     memo: [u8; 512],
     is_outgoing: bool,
 } //TODO: add note_type?
@@ -1167,6 +1168,7 @@ pub extern "C" fn orchard_wallet_get_txdata(
                     action_idx: idx as u32,
                     recipient: Box::into_raw(Box::new(*addr)),
                     value: note.value().inner() as i64,
+                    note_type: note.note_type().to_bytes(),
                     memo: *memo,
                     is_outgoing,
                 };

--- a/src/wallet/orchard.h
+++ b/src/wallet/orchard.h
@@ -149,12 +149,13 @@ class OrchardActionOutput {
 private:
     libzcash::OrchardRawAddress recipient;
     CAmount noteValue;
+    NoteType noteType;
     std::array<unsigned char, 512> memo;
     bool isOutgoing;
 public:
     OrchardActionOutput(
-            libzcash::OrchardRawAddress recipient, CAmount noteValue, std::array<unsigned char, 512> memo, bool isOutgoing):
-            recipient(recipient), noteValue(noteValue), memo(memo), isOutgoing(isOutgoing) { }
+            libzcash::OrchardRawAddress recipient, CAmount noteValue, NoteType noteType, std::array<unsigned char, 512> memo, bool isOutgoing):
+            recipient(recipient), noteValue(noteValue), noteType(noteType), memo(memo), isOutgoing(isOutgoing) { }
 
     const libzcash::OrchardRawAddress& GetRecipient() const {
         return recipient;
@@ -162,6 +163,10 @@ public:
 
     CAmount GetNoteValue() const {
         return noteValue;
+    }
+
+    NoteType GetNoteType() const {
+        return noteType;
     }
 
     const std::array<unsigned char, 512>& GetMemo() const {
@@ -479,9 +484,11 @@ public:
     static void PushOutputAction(void* receiver, RawOrchardActionOutput rawOutput) {
         std::array<unsigned char, 512> memo;
         std::move(std::begin(rawOutput.memo), std::end(rawOutput.memo), memo.begin());
+        NoteType noteType(rawOutput.noteTypeRaw);
         auto output = OrchardActionOutput(
                 libzcash::OrchardRawAddress(rawOutput.recipient),
                 rawOutput.noteValue,
+                noteType,
                 memo,
                 rawOutput.isOutgoing);
 


### PR DESCRIPTION
This PR adds note type support for `FFIActionOutput`, `RawOrchardActionOutput`, and `OrchardActionOutput`.