### PR TITLE
Update to the `z_viewtransaction` RPC command (Review fifth)

### DIFF
--- a/src/note_type.cpp
+++ b/src/note_type.cpp
@@ -40,3 +40,9 @@ std::string NoteType::get_type_id_str() {
     }
     return ss.str();
 }
+
+std::string NoteType::get_type_name() {
+    if (this->get_type_id_str() == "6743f93a6ebda72a8c7c5a2b7fa304fe32b29b4f706aa8f7420f3d8e7a59702f")
+        return "ZEC";
+    return "Invalid type!";  //TODO: Add functionality for derived types
+}

--- a/src/note_type.cpp
+++ b/src/note_type.cpp
@@ -3,6 +3,7 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 #include "note_type.h"
+#include <sstream>
 
 NoteType::NoteType() { // default constructor
     unsigned char* note_type_ret = new unsigned char[ZC_ORCHARD_NOTE_TYPE_SIZE];
@@ -27,4 +28,15 @@ void NoteType::getNoteType(unsigned char noteType[ZC_ORCHARD_NOTE_TYPE_SIZE]) {
 
 const unsigned char *NoteType::get_type() {
     return &type_id[0];
+}
+
+std::string NoteType::get_type_id_str() {
+    std::stringstream ss;
+    ss << std::hex;
+    for (int i = 0; i < ZC_ORCHARD_NOTE_TYPE_SIZE; i++) {
+        if ((int)type_id[i] < 16)
+            ss << "0";
+        ss << (int)type_id[i];
+    }
+    return ss.str();
 }

--- a/src/note_type.h
+++ b/src/note_type.h
@@ -25,6 +25,7 @@ public:
     const unsigned char* get_type();
     void getNoteType(unsigned char noteType[ZC_ORCHARD_NOTE_TYPE_SIZE]);
     std::string get_type_id_str();
+    std::string get_type_name();
 };
 
 #endif //ZCASH_NOTE_TYPE_H

--- a/src/note_type.h
+++ b/src/note_type.h
@@ -24,6 +24,7 @@ public:
 
     const unsigned char* get_type();
     void getNoteType(unsigned char noteType[ZC_ORCHARD_NOTE_TYPE_SIZE]);
+    std::string get_type_id_str();
 };
 
 #endif //ZCASH_NOTE_TYPE_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4757,6 +4757,7 @@ UniValue z_viewtransaction(const UniValue& params, bool fHelp)
         auto outpoint = orchardActionSpend.GetOutPoint();
         auto receivedAt = orchardActionSpend.GetReceivedAt();
         auto noteValue = orchardActionSpend.GetNoteValue();
+        auto noteType = orchardActionSpend.GetNoteType();
 
         std::optional<std::string> addrStr;
         auto addr = pwalletMain->GetPaymentAddressForRecipient(txid, receivedAt);
@@ -4777,12 +4778,14 @@ UniValue z_viewtransaction(const UniValue& params, bool fHelp)
         }
         entry.pushKV("value", ValueFromAmount(noteValue));
         entry.pushKV("valueZat", noteValue);
+        entry.pushKV("note_type_id", noteType.get_type_id_str());
         spends.push_back(entry);
     }
 
     // Orchard outputs
     for (const auto& [actionIdx, orchardActionOutput]  : orchardActions.GetOutputs()) {
         auto noteValue = orchardActionOutput.GetNoteValue();
+        auto noteType = orchardActionOutput.GetNoteType();
         auto recipient = orchardActionOutput.GetRecipient();
         auto memo = orchardActionOutput.GetMemo();
 
@@ -4807,6 +4810,7 @@ UniValue z_viewtransaction(const UniValue& params, bool fHelp)
         }
         entry.pushKV("value", ValueFromAmount(noteValue));
         entry.pushKV("valueZat", noteValue);
+        entry.pushKV("note_type_id", noteType.get_type_id_str());
         addMemo(entry, memo);
         outputs.push_back(entry);
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4779,6 +4779,7 @@ UniValue z_viewtransaction(const UniValue& params, bool fHelp)
         entry.pushKV("value", ValueFromAmount(noteValue));
         entry.pushKV("valueZat", noteValue);
         entry.pushKV("note_type_id", noteType.get_type_id_str());
+        entry.pushKV("note_type", noteType.get_type_name());
         spends.push_back(entry);
     }
 
@@ -4811,6 +4812,7 @@ UniValue z_viewtransaction(const UniValue& params, bool fHelp)
         entry.pushKV("value", ValueFromAmount(noteValue));
         entry.pushKV("valueZat", noteValue);
         entry.pushKV("note_type_id", noteType.get_type_id_str());
+        entry.pushKV("note_type", noteType.get_type_name());
         addMemo(entry, memo);
         outputs.push_back(entry);
     }


### PR DESCRIPTION
This PR adds note type information to the output of the `z_viewtransaction` RPC command.

More specifically, the details of the Orchard spend and output parts of the requested transaction now also provide note_type information such as the type and the alias.
The current default is to set these to the native ZEC token.